### PR TITLE
quiet flag to hide script name in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ your `"scripts"`:
 The keys of the `"watch"` config should match the names of your `"scripts"`, and
 the values should be a glob pattern or array of glob patterns to watch.
 
-If you need to watch files with extensions other than those that `nodemon` watches [by default](https://github.com/remy/nodemon#specifying-extension-watch-list) (`.js`, `.coffee`, `.litcoffee`), you can set the value to an object with `patterns` and `extensions` keys. You can also add an `ignore` key (a list or a string) to ignore specific files.
+If you need to watch files with extensions other than those that `nodemon` watches [by default](https://github.com/remy/nodemon#specifying-extension-watch-list) (`.js`, `.coffee`, `.litcoffee`), you can set the value to an object with `patterns` and `extensions` keys. You can also add an `ignore` key (a list or a string) to ignore specific files. Finally, you can add a `quiet` flag to hide the script name in any output on stdout or stderr.
 
 ```javascript
 {
@@ -34,7 +34,8 @@ If you need to watch files with extensions other than those that `nodemon` watch
     "test": {
       "patterns": ["src", "test"],
       "extensions": "js,jsx",
-      "ignore": "src/vendor/external.min.js"
+      "ignore": "src/vendor/external.min.js",
+      "quiet": "true"
     }
   },
   "scripts": {

--- a/watch-package.js
+++ b/watch-package.js
@@ -44,11 +44,13 @@ module.exports = function watchPackage (pkgDir, exit) {
     var patterns = null
     var extensions = null
     var ignores = null
+    var quiet = null
 
     if (typeof pkg.watch[script] === 'object' && !Array.isArray(pkg.watch[script])) {
       patterns = pkg.watch[script].patterns
       extensions = pkg.watch[script].extensions
       ignores = pkg.watch[script].ignore
+      quiet = pkg.watch[script].quiet
     } else {
       patterns = pkg.watch[script]
     }
@@ -76,8 +78,13 @@ module.exports = function watchPackage (pkgDir, exit) {
       cwd: pkgDir,
       stdio: 'pipe'
     })
-    proc.stdout.pipe(prefixer('[' + script + ']')).pipe(stdin.stdout)
-    proc.stderr.pipe(prefixer('[' + script + ']')).pipe(stdin.stderr)
+    if (quiet === 'true') {
+      proc.stdout.pipe(stdin.stdout)
+      proc.stderr.pipe(stdin.stderr)
+    } else {
+      proc.stdout.pipe(prefixer('[' + script + ']')).pipe(stdin.stdout)
+      proc.stderr.pipe(prefixer('[' + script + ']')).pipe(stdin.stderr)
+    }
   })
 
   return stdin


### PR DESCRIPTION
This adds an optional "quiet" flag to the full script config object, which if set to `"true"` will hide the script name prefix in the output on stdout and stderr.