### PR TITLE
fix how `prefix` is inserted into output

### DIFF
--- a/watch-package.js
+++ b/watch-package.js
@@ -95,7 +95,7 @@ function prefixer (prefix) {
   return through(function (line, _, callback) {
     line = line.toString()
     if (!line.match('to restart at any time')) {
-      this.push(prefix + ' ' + line)
+      this.push(line.replace(/^/gm, prefix + ' '))
     }
     callback()
   })


### PR DESCRIPTION
The `line` can be a multiline string. This commit changes how the `prefix` is inserted to use a multiline regular expression instead of prepending one to `line`.